### PR TITLE
Update webpack-config.factory.ts

### DIFF
--- a/lib/webpack-config.factory.ts
+++ b/lib/webpack-config.factory.ts
@@ -9,17 +9,22 @@ export interface WebpackEntries {
   [key: string]: string | string[];
 }
 
+export interface WebpackAlias {
+  [key: string]: string | string[];
+}
+
 export class WebpackConfigFactory {
   static create(
     webpack: any,
     entry: WebpackEntries = defaultEntries,
+    alias: WebpackAlias = {},
     currentDir: string = process.cwd()
   ) {
     return {
       entry,
       mode: 'none',
       target: 'node',
-      resolve: { extensions: ['.ts', '.js'] },
+      resolve: { alias, extensions: ['.ts', '.js'] },
       externals: [/node_modules/],
       output: {
         // Puts the output at the root of the dist folder


### PR DESCRIPTION
With this configuration tsconfig paths are not supported. Add an alias argument to solve this problem.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ X ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ X ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Now it is not possible to work with the tsconfig paths. If you do npm run webpack:server, the paths were not identified. In a normal webpack configuration this can be solved by adding them as alias.

Issue Number: N/A


## What is the new behavior?
Make it possible to add an alias to the webpack configuration

## Does this PR introduce a breaking change?
```
[ ] Yes
[  X ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information