### PR TITLE
fix(schematic): ensure nodemon dev dependency for serve-script

### DIFF
--- a/schematics/install/index.ts
+++ b/schematics/install/index.ts
@@ -70,6 +70,11 @@ function addDependenciesAndScripts(options: UniversalOptions): Rule {
       name: 'webpack-cli',
       version: '^3.1.0'
     });
+    addPackageJsonDependency(host, {
+      type: NodeDependencyType.Dev,
+      name: 'nodemon',
+      version: '^1.18.11'
+    });
 
     const pkgPath = '/package.json';
     const buffer = host.read(pkgPath);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2574412/55978501-eaa66c80-5c5d-11e9-8891-7b23a7349d04.png)

Make sure nodemon is installed, since some folks won't have it globally installed. serve-script won't run without it