### PR TITLE
fix(install): include clientProject.root in fileReplacements

### DIFF
--- a/schematics/install/express-engine/rules.ts
+++ b/schematics/install/express-engine/rules.ts
@@ -58,8 +58,8 @@ export function updateConfigFile(options: UniversalOptions): Rule {
       production: {
         fileReplacements: [
           {
-            replace: 'src/environments/environment.ts',
-            with: 'src/environments/environment.prod.ts'
+            replace: `${clientProject.root}src/environments/environment.ts`,
+            with: `${clientProject.root}src/environments/environment.prod.ts`
           }
         ]
       }


### PR DESCRIPTION
When `clientProject.root` is not empty,, `clientProject.architect.server.configurations.production.fileReplacements` paths are invalid.

`src\environments\environment.prod.ts path in file replacements does not exist.`
