### PR TITLE
feature(): allow implementing custom cache key genereting logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,39 @@ The `forRoot()` method takes an options object with a few useful properties.
 | `rootStaticPath` | string?    | Static files root directory (default: `*.*`) |
 | `renderPath` | string?    | Path to render Angular app (default: `*`) |
 | `extraProviders` | StaticProvider[]?    | The platform level providers for the current render request |
+| `cache` | boolean? \| object?    | cache options, description below (default: `true`) |
+
+### Cache
+
+| Property        | Type           | Description  |
+| ------------- | ------------- | ----- |
+| `expiresIn`      | number? | Cache expiration in milliseconds (default: `60000`) |
+| `storage`      | CacheStorage?      | Interface for implementing custom cache storage (default: in memory) |
+| `keyGenerator` | CacheKeyGenerator?      | Interface for implementing custom cache key generation logic (default: by url) |
+
+```typescript
+AngularUniversalModule.forRoot({
+      bootstrap: AppServerModule,
+      viewsPath: join(process.cwd(), 'dist/{APP_NAME}/browser'),
+      cache: {
+        storage: new InMemoryCacheStorage(),
+        expiresIn: DEFAULT_CACHE_EXPIRATION_TIME,
+        keyGenerator: new CustomCacheKeyGenerator(),
+      }
+    })
+```
+
+### Example for CacheKeyGenerator:
+```typescript
+export class CustomCacheKeyGenerator implements CacheKeyGenerator {
+  generateCacheKey(request: Request): string {
+    const md = new MobileDetect(request.headers['user-agent']);
+    const ismobile = md.mobile() ? 'mobile' : 'desktop';
+    return (request.hostname + request.originalUrl + ismobile).toLowerCase();
+  }
+}
+```
+
 
 ## Request and Response Providers
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The `forRoot()` method takes an options object with a few useful properties.
 | `rootStaticPath` | string?    | Static files root directory (default: `*.*`) |
 | `renderPath` | string?    | Path to render Angular app (default: `*`) |
 | `extraProviders` | StaticProvider[]?    | The platform level providers for the current render request |
-| `cache` | boolean? \| object?    | cache options, description below (default: `true`) |
+| `cache` | boolean? \| object?    | Cache options, description below (default: `true`) |
 
 ### Cache
 
@@ -90,17 +90,18 @@ The `forRoot()` method takes an options object with a few useful properties.
 
 ```typescript
 AngularUniversalModule.forRoot({
-      bootstrap: AppServerModule,
-      viewsPath: join(process.cwd(), 'dist/{APP_NAME}/browser'),
-      cache: {
-        storage: new InMemoryCacheStorage(),
-        expiresIn: DEFAULT_CACHE_EXPIRATION_TIME,
-        keyGenerator: new CustomCacheKeyGenerator(),
-      }
-    })
+  bootstrap: AppServerModule,
+  viewsPath: join(process.cwd(), 'dist/{APP_NAME}/browser'),
+  cache: {
+    storage: new InMemoryCacheStorage(),
+    expiresIn: DEFAULT_CACHE_EXPIRATION_TIME,
+    keyGenerator: new CustomCacheKeyGenerator(),
+  }
+})
 ```
 
 ### Example for CacheKeyGenerator:
+
 ```typescript
 export class CustomCacheKeyGenerator implements CacheKeyGenerator {
   generateCacheKey(request: Request): string {
@@ -110,7 +111,6 @@ export class CustomCacheKeyGenerator implements CacheKeyGenerator {
   }
 }
 ```
-
 
 ## Request and Response Providers
 

--- a/lib/cache/cahce-key-by-original-url.generator.ts
+++ b/lib/cache/cahce-key-by-original-url.generator.ts
@@ -1,0 +1,7 @@
+import { CacheKeyGenerator } from '../interfaces/cache-key-generator.interface';
+
+export class CacheKeyByOriginalUrlGenerator implements CacheKeyGenerator {
+  generateCacheKey(request: any): string {
+    return request.originalUrl;
+  }
+}

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,7 @@
 export * from './angular-universal.module';
 export * from './cache/in-memory-cache.storage';
 export * from './interfaces/angular-universal-options.interface';
+export * from './cache/cahce-key-by-original-url.generator';
 export * from './interfaces/cache-storage.interface';
+export * from './interfaces/cache-key-generator.interface';
 export * from './utils/domino.utils';

--- a/lib/interfaces/angular-universal-options.interface.ts
+++ b/lib/interfaces/angular-universal-options.interface.ts
@@ -1,4 +1,5 @@
 import { CacheStorage } from './cache-storage.interface';
+import { CacheKeyGenerator } from './cache-key-generator.interface';
 
 export interface AngularUniversalOptions {
   /**
@@ -32,6 +33,7 @@ export interface AngularUniversalOptions {
     | {
         expiresIn?: number;
         storage?: CacheStorage;
+        keyGenerator?: CacheKeyGenerator;
       };
   /**
    * Module to bootstrap

--- a/lib/interfaces/cache-key-generator.interface.ts
+++ b/lib/interfaces/cache-key-generator.interface.ts
@@ -1,0 +1,3 @@
+export interface CacheKeyGenerator {
+  generateCacheKey(request: any): string;
+}


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently, cache keys are determined solely by originalUrl.

Issue Number: N/A


## What is the new behavior?
Defined an interface for generating cache keys.
User should add an implementing instance to the Cache options object,
otherwise, the default option will be used (by originalUrl).

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information