### PR TITLE
feat: add errorHandler as an option in case of rendering error

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,23 +70,24 @@ export class ApplicationModule {}
 
 The `forRoot()` method takes an options object with a few useful properties.
 
-| Property        | Type           | Description  |
-| ------------- | ------------- | ----- |
-| `viewsPath`      | string | The directory where the module should look for client bundle (Angular app) |
-| `bootstrap`      | Function      |   Angular server module reference (`AppServerModule`). |
-| `templatePath` | string?      | Path to index file (default: `{viewsPaths}/index.html`) |
-| `rootStaticPath` | string?    | Static files root directory (default: `*.*`) |
-| `renderPath` | string?    | Path to render Angular app (default: `*`) |
-| `extraProviders` | StaticProvider[]?    | The platform level providers for the current render request |
-| `cache` | boolean? \| object?    | Cache options, description below (default: `true`) |
+| Property         | Type                | Description                                                                |
+| ---------------- | ------------------- | -------------------------------------------------------------------------- |
+| `viewsPath`      | string              | The directory where the module should look for client bundle (Angular app) |
+| `bootstrap`      | Function            | Angular server module reference (`AppServerModule`).                       |
+| `templatePath`   | string?             | Path to index file (default: `{viewsPaths}/index.html`)                    |
+| `rootStaticPath` | string?             | Static files root directory (default: `*.*`)                               |
+| `renderPath`     | string?             | Path to render Angular app (default: `*`)                                  |
+| `extraProviders` | StaticProvider[]?   | The platform level providers for the current render request                |
+| `cache`          | boolean? \| object? | Cache options, description below (default: `true`)                         |
+| `errorHandler`   | Function?           | Callback to be called in case of a rendering error                         |
 
 ### Cache
 
-| Property        | Type           | Description  |
-| ------------- | ------------- | ----- |
-| `expiresIn`      | number? | Cache expiration in milliseconds (default: `60000`) |
-| `storage`      | CacheStorage?      | Interface for implementing custom cache storage (default: in memory) |
-| `keyGenerator` | CacheKeyGenerator?      | Interface for implementing custom cache key generation logic (default: by url) |
+| Property       | Type               | Description                                                                    |
+| -------------- | ------------------ | ------------------------------------------------------------------------------ |
+| `expiresIn`    | number?            | Cache expiration in milliseconds (default: `60000`)                            |
+| `storage`      | CacheStorage?      | Interface for implementing custom cache storage (default: in memory)           |
+| `keyGenerator` | CacheKeyGenerator? | Interface for implementing custom cache key generation logic (default: by url) |
 
 ```typescript
 AngularUniversalModule.forRoot({

--- a/lib/interfaces/angular-universal-options.interface.ts
+++ b/lib/interfaces/angular-universal-options.interface.ts
@@ -36,6 +36,14 @@ export interface AngularUniversalOptions {
         keyGenerator?: CacheKeyGenerator;
       };
   /**
+   * Callback to be called in case of a rendering error.
+   */
+  errorHandler?: (params: {
+    err?: Error;
+    html?: string;
+    renderCallback: (err: any, content: string) => void;
+  }) => void;
+  /**
    * Module to bootstrap
    */
   bootstrap: any;

--- a/lib/utils/setup-universal.utils.ts
+++ b/lib/utils/setup-universal.utils.ts
@@ -30,6 +30,15 @@ export function setupUniversal(app: any, ngOptions: AngularUniversalOptions) {
         ...(ngOptions.extraProviders || [])
       ]
     })(_, options, (err, html) => {
+      if (err && ngOptions.errorHandler) {
+        return ngOptions.errorHandler({ err, html, renderCallback: callback });
+      }
+
+      if (err) {
+        console.error(err);
+        return callback(err);
+      }
+
       if (cacheOptions.isEnabled && cacheKey) {
         cacheOptions.storage.set(cacheKey, html, cacheOptions.expiresIn);
       }


### PR DESCRIPTION

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Currently if there is an error during the server rendering the server fails silently without the possibility to hook-up in the rendering process and handle the error (ex: return an error page or the default index.html without SSR for browser fallback).

Issue Number: N/A


## What is the new behavior?
Added an option to be able to pass an error handler for custom error handling logic. By default the error logged in the console and the renderingCallback is resolved with the error in order to make debugging easier. 


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information