### PR TITLE
Update setup-universal.utils.ts

### DIFF
--- a/lib/utils/setup-universal.utils.ts
+++ b/lib/utils/setup-universal.utils.ts
@@ -50,7 +50,7 @@ export function setupUniversal(app: any, ngOptions: AngularUniversalOptions) {
   app.set('views', ngOptions.viewsPath);
 
   // Serve static files
-  app.get(
+  app.use(
     ngOptions.rootStaticPath,
     express.static(ngOptions.viewsPath, {
       maxAge: 600


### PR DESCRIPTION
Should be app.use() instead of app.get(). 
Otherwise there are problems with resolving files in serve-static, because the path gets not stripped with app.get().
https://github.com/expressjs/serve-static

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the current behavior?
If a root-static path other than *.* is used, file resolving in express-static does not behave as expected (404)

Issue Number: N/A


## What is the new behavior?
rootStaticPath behaves as expected and resolves relative to viewsPath.


## Does this PR introduce a breaking change?
```
[ x ] Yes
[ ] No
```
Users that somehow worked-around the file resolving issue need to undo their workaround.


## Other information