### PR TITLE
docs(readme): Adding `@angular-builders/custom-webpack` example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,12 +193,6 @@ export default (
             'cache-manager',
             'class-validator',
             'class-transform',
-            'apollo-server-fastify',
-            'bufferutil',
-            'utf-8-validate',
-            'graphql-ws',
-            'ws',
-            'ts-morph'
           ];
 
           if (!lazyImpots.includes(resource)) {

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ export class NotFoundComponent {
 
 ## Custom Webpack
 
-In some situations, it may be required to customize the `webpack` build while using `@nestjs/ng-universal`, especially when additional dependencies are include which include native NodeJS code.
+In some situations, it may be required to customize the `webpack` build while using `@nestjs/ng-universal`, especially when additional dependencies are included (that rely on native Node.js code).
 
 To add a customizable `webpack` config to your project, it is recommended to install [@angular-builders/custom-webpack](https://www.npmjs.com/package/@angular-builders/custom-webpack) in the project and to set your builders appropriately.
 


### PR DESCRIPTION
Adding an example of adding `@angular-builders/custom-webpack` to the
[README](./README.md) to show how to work around needing to import Node
modules into a `@nestjs/ng-universal` server-side application.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?


```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[X] Other... Please describe: README update
```

## What is the current behavior?
Updated the [README](./README.md) to show an example of using `@nestjs/ng-universal` with `@angular-builders/custom-webpack`.

Issue Number: https://github.com/nestjs/ng-universal/issues/657


## What is the new behavior?
No new behavior. Just documentation.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information