### PR TITLE
refactor(@nestjs/ng-universal): Changing logging to use NestJS logging class

### DIFF
--- a/lib/utils/setup-universal.utils.ts
+++ b/lib/utils/setup-universal.utils.ts
@@ -1,3 +1,4 @@
+import { Logger } from '@nestjs/common';
 import { ngExpressEngine } from '@nguniversal/express-engine';
 import * as express from 'express';
 import { CacheKeyByOriginalUrlGenerator } from '../cache/cache-key-by-original-url.generator';
@@ -5,6 +6,8 @@ import { InMemoryCacheStorage } from '../cache/in-memory-cache.storage';
 import { AngularUniversalOptions } from '../interfaces/angular-universal-options.interface';
 
 const DEFAULT_CACHE_EXPIRATION_TIME = 60000; // 60 seconds
+
+const logger = new Logger('AngularUniversalModule');
 
 export function setupUniversal(app: any, ngOptions: AngularUniversalOptions) {
   const cacheOptions = getCacheOptions(ngOptions);
@@ -36,7 +39,7 @@ export function setupUniversal(app: any, ngOptions: AngularUniversalOptions) {
       }
 
       if (err) {
-        console.error(err);
+        logger.error(err);
         return callback(err);
       }
 


### PR DESCRIPTION
Small code change in `setup-universal.util.ts` to use the NestJS logging
facility rather than `console.error` for error printing.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
Current logging was using `console.error` instead of the built-in logging facilities of the NestJS framework.

Issue Number: N/A


## What is the new behavior?
Module now uses the `Logger` class from `@nestjs/common` to handle error logging.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
