### PR TITLE
fix(schematics): replace port dot notation with bracket notation

### DIFF
--- a/schematics/install/files/root/server/main.ts
+++ b/schematics/install/files/root/server/main.ts
@@ -4,7 +4,7 @@ import { AppModule } from './app.module';
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.setGlobalPrefix('api');
-  await app.listen(process.env.PORT || <%= serverPort %>);
+  await app.listen(process.env['PORT'] || <%= serverPort %>);
 }
 
 // Webpack will replace 'require' with '__webpack_require__'

--- a/schematics/install/tests/index.spec.ts
+++ b/schematics/install/tests/index.spec.ts
@@ -81,7 +81,7 @@ describe('ng-add', () => {
 
     // Assert
     expect(server).toContain("import 'zone.js/node'");
-    expect(main).toContain('await app.listen(process.env.PORT || 4000)');
+    expect(main).toContain('await app.listen(process.env[\'PORT\'] || 4000)');
     expect(appModule).toContain(
       "viewsPath: join(process.cwd(), 'dist/ng-universal-app/browser')"
     );


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #987

Starting a dev server or building the application results in a ``this.debug is not a function`` or sometimes in a ``TS4111: Property 'PORT' comes from an index signature, so it must be accessed with ['PORT'].`` error.

## What is the new behavior?

Starting a dev server or building the application

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
