### PR TITLE
Add domino dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@nguniversal/common": "16.0.0",
         "@nguniversal/express-engine": "16.0.0",
         "@schematics/angular": "16.0.0",
+        "domino": "^2.1.6",
         "memory-cache": "0.2.0"
       },
       "devDependencies": {
@@ -3202,6 +3203,11 @@
       "funding": {
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
+    },
+    "node_modules/domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "node_modules/domutils": {
       "version": "2.8.0",
@@ -11005,6 +11011,11 @@
       "requires": {
         "domelementtype": "^2.2.0"
       }
+    },
+    "domino": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/domino/-/domino-2.1.6.tgz",
+      "integrity": "sha512-3VdM/SXBZX2omc9JF9nOPCtDaYQ67BGp5CoLpIQlO2KCAPETs8TcDHacF26jXadGbvUteZzRTeos2fhID5+ucQ=="
     },
     "domutils": {
       "version": "2.8.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@nguniversal/common": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
     "@nguniversal/express-engine": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
     "@schematics/angular": "16.0.0",
-    "domino": "^2.1.6",
+    "domino": "2.1.6",
     "memory-cache": "0.2.0"
   },
   "schematics": "./schematics/collection.json",

--- a/package.json
+++ b/package.json
@@ -50,9 +50,10 @@
   },
   "dependencies": {
     "@angular-devkit/schematics": "16.0.0",
-    "@nguniversal/common": "16.0.0",
-    "@nguniversal/express-engine": "16.0.0",
+    "@nguniversal/common": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
+    "@nguniversal/express-engine": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
     "@schematics/angular": "16.0.0",
+    "domino": "^2.1.6",
     "memory-cache": "0.2.0"
   },
   "schematics": "./schematics/collection.json",


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/nestjs/nest/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## What is the current behavior?
After upgrading to Angular 16, I can see the following error:
```
./node_modules/@nestjs/ng-universal/dist/utils/domino.utils.js:8:15-32 - Error: Module not found: Error: Can't resolve 'domino' in '/node_modules/@nestjs/ng-universal/dist/utils'
```

Issue Number: #1017 


## What is the new behavior?
The `domino` dependency has been added to fix that issue.

## Does this PR introduce a breaking change?
- [ ] Yes
- [x] No
